### PR TITLE
refactor: 使用 logger 取代 print 並更新測試

### DIFF
--- a/spider/crawlers/robots_handler.py
+++ b/spider/crawlers/robots_handler.py
@@ -6,6 +6,10 @@ from typing import Dict, Optional
 import types
 
 from spider.utils.connection_manager import EnhancedConnectionManager
+from spider.utils.enhanced_logger import get_spider_logger
+
+# 建立模組專用的記錄器
+logger = get_spider_logger("robots_handler")
 
 # 全域快取，避免重複下載 robots.txt
 _robots_cache: Dict[str, urllib.robotparser.RobotFileParser] = {}
@@ -45,7 +49,13 @@ async def fetch_and_parse(domain: str, connection_manager: Optional[EnhancedConn
                     delay = rp.crawl_delay(USER_AGENT)
                     if delay is not None:
                         _crawl_delay_cache[netloc] = delay
+                    # 成功取得 robots.txt 時輸出除錯訊息
+                    logger.debug(f"成功取得 {robots_url}")
                 else:
+                    # 取得 robots.txt 失敗時紀錄錯誤
+                    logger.error(
+                        f"無法取得 {robots_url}，狀態碼 {response.status}"
+                    )
                     rp.parse([])
         else:
             response = await cm.get(robots_url)
@@ -55,9 +65,15 @@ async def fetch_and_parse(domain: str, connection_manager: Optional[EnhancedConn
                 delay = rp.crawl_delay(USER_AGENT)
                 if delay is not None:
                     _crawl_delay_cache[netloc] = delay
+                logger.debug(f"成功取得 {robots_url}")
             else:
+                logger.error(
+                    f"無法取得 {robots_url}，狀態碼 {response.status}"
+                )
                 rp.parse([])
-    except Exception:
+    except Exception as e:  # noqa: BLE001
+        # 捕捉未知例外並記錄
+        logger.error(f"下載 {robots_url} 時發生例外: {e}")
         rp.parse([])
     finally:
         if close_manager:
@@ -74,7 +90,11 @@ async def is_allowed(url: str, connection_manager: Optional[EnhancedConnectionMa
     rp = _robots_cache.get(netloc)
     if not rp:
         return True
-    return rp.can_fetch(USER_AGENT, url)
+    allowed = rp.can_fetch(USER_AGENT, url)
+    if not allowed:
+        # 不允許時記錄資訊
+        logger.info(f"URL 被 robots.txt 禁止: {url}")
+    return allowed
 
 async def get_crawl_delay(domain: str, connection_manager: Optional[EnhancedConnectionManager] = None) -> Optional[float]:
     """取得指定網域的 crawl-delay 秒數"""


### PR DESCRIPTION
## Summary
- 使用 `get_spider_logger` 替換 `sitemap_parser` 與 `robots_handler` 中的 `print`
- 擴充 `robots_handler` 以記錄抓取失敗與被禁止的網址
- 新增 `robots_handler` 失敗時的日誌測試

## Testing
- ⚠️ `pytest -q`（環境缺少 pytest，代理阻擋安裝）

------
https://chatgpt.com/codex/tasks/task_e_68a2ee9b05a88323b241c80cc77442c8