### PR TITLE
chore: use tabs for db scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,12 @@ db-clear:
 	@$(PYTHON) -m scripts.database.make-clear --force
 
 db-tables:
-        @echo "📊  檢查資料庫各表記錄數..."
-        @$(PYTHON) -m scripts.database.make-tables
+	@echo "📊  檢查資料庫各表記錄數..."
+	@$(PYTHON) -m scripts.database.make-tables
 
 migrate-supabase:
-        @echo "🚚  將 PostgreSQL 資料遷移至 Supabase..."
-        @$(PYTHON) -m scripts.database.migrate_to_supabase
+	@echo "🚚  將 PostgreSQL 資料遷移至 Supabase..."
+	@$(PYTHON) -m scripts.database.migrate_to_supabase
 
 # --- 專案管理 ---
 


### PR DESCRIPTION
## Summary
- replace 8-space indent with tabs for `db-tables`, `migrate-supabase`, and later targets

## Testing
- `make test` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a3000d04e88323a0266f4e277ef426