### PR TITLE
feat: 依網域預抓取 robots 並動態調整延遲

### DIFF
--- a/spider/crawlers/robots_handler.py
+++ b/spider/crawlers/robots_handler.py
@@ -52,8 +52,8 @@ async def fetch_and_parse(domain: str, connection_manager: Optional[EnhancedConn
                     # 成功取得 robots.txt 時輸出除錯訊息
                     logger.debug(f"成功取得 {robots_url}")
                 else:
-                    # 取得 robots.txt 失敗時紀錄錯誤
-                    logger.error(
+                    # 取得 robots.txt 失敗時以警告紀錄
+                    logger.warning(
                         f"無法取得 {robots_url}，狀態碼 {response.status}"
                     )
                     rp.parse([])
@@ -67,13 +67,13 @@ async def fetch_and_parse(domain: str, connection_manager: Optional[EnhancedConn
                     _crawl_delay_cache[netloc] = delay
                 logger.debug(f"成功取得 {robots_url}")
             else:
-                logger.error(
+                logger.warning(
                     f"無法取得 {robots_url}，狀態碼 {response.status}"
                 )
                 rp.parse([])
     except Exception as e:  # noqa: BLE001
-        # 捕捉未知例外並記錄
-        logger.error(f"下載 {robots_url} 時發生例外: {e}")
+        # 捕捉未知例外並記錄為警告
+        logger.warning(f"下載 {robots_url} 時發生例外: {e}")
         rp.parse([])
     finally:
         if close_manager:

--- a/spider/tests/test_progressive_crawler.py
+++ b/spider/tests/test_progressive_crawler.py
@@ -119,7 +119,11 @@ async def test_crawl_batch_order_and_status() -> None:
     processed = await crawler.crawl_batch()
 
     assert processed == 2
-    assert conn.requested == ["http://example.com/2", "http://example.com/1"]
+    assert conn.requested == [
+        "https://example.com/robots.txt",
+        "http://example.com/2",
+        "http://example.com/1",
+    ]
     assert scheduler.statuses["1"] == CrawlStatus.COMPLETED
     assert scheduler.statuses["2"] == CrawlStatus.COMPLETED
 

--- a/spider/tests/test_robots_handler.py
+++ b/spider/tests/test_robots_handler.py
@@ -74,15 +74,15 @@ async def test_is_allowed_and_get_crawl_delay() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_and_parse_logs_error(caplog) -> None:
-    """當取得 robots.txt 失敗時應記錄錯誤"""
+async def test_fetch_and_parse_logs_warning(caplog) -> None:
+    """當取得 robots.txt 失敗時應記錄警告"""
 
     robots_handler._robots_cache.clear()
     robots_handler._crawl_delay_cache.clear()
 
     cm = ErrorConnectionManager()
 
-    with caplog.at_level(logging.ERROR, logger="robots_handler"):
+    with caplog.at_level(logging.WARNING, logger="robots_handler"):
         await robots_handler.fetch_and_parse("https://example.com", cm)
 
     assert any("404" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- 依網域預先抓取 robots.txt 並依 crawl-delay 調整速率限制
- robots.txt 下載失敗改記錄警告不中斷
- 更新相關單元測試

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3151b7d588323b928445d91a6a6f7