### PR TITLE
feat: add robots precheck and concurrent crawling

### DIFF
--- a/scripts/2_crawl_content.py
+++ b/scripts/2_crawl_content.py
@@ -31,7 +31,14 @@ async def main(batch_size: int) -> None:
     async with EnhancedDatabaseManager() as db_manager:
         scheduler = URLScheduler(db_manager)
         cm = EnhancedConnectionManager(rate_limiter=AdaptiveRateLimiter())
-        crawler = ProgressiveCrawler(scheduler, cm, RetryManager(), batch_size=batch_size)
+        # 以 batch_size 同時設定批次大小與並行數量
+        crawler = ProgressiveCrawler(
+            scheduler,
+            cm,
+            RetryManager(),
+            batch_size=batch_size,
+            concurrency=batch_size,
+        )
         processed = await crawler.crawl_batch()
         logger.info(f"本次處理 {processed} 個 URL")
         logger.log_statistics()


### PR DESCRIPTION
## Summary
- respect robots.txt before pipeline execution and abort on disallow or excessive crawl-delay
- run URL discovery and content crawling concurrently
- align ProgressiveCrawler concurrency with batch size and log final statistics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33b9bf19c8323826ca2ad77729b88