### PR TITLE
feat: 串流抓取 URL

### DIFF
--- a/spider/crawlers/url_scheduler.py
+++ b/spider/crawlers/url_scheduler.py
@@ -99,15 +99,15 @@ class URLScheduler:
 
         return total
 
-    async def dequeue_batch(self, batch_size: int) -> List[DiscoveredURLModel]:
-        """取出一批待處理的 URL
+    async def dequeue_stream(self, batch_size: int):
+        """以串流方式取出待處理的 URL"""
 
-        Args:
-            batch_size: 批次大小
-        Returns:
-            待處理的 URL 模型列表
-        """
-        return await self.db_manager.get_pending_urls(batch_size)
+        while True:
+            batch = await self.db_manager.get_pending_urls(batch_size)
+            if not batch:
+                break
+            for item in batch:
+                yield item
 
     async def update_status(self, url_id: str, status: CrawlStatus, error_message: str | None = None) -> bool:
         """更新指定 URL 的狀態"""

--- a/spider/tests/test_progressive_crawler.py
+++ b/spider/tests/test_progressive_crawler.py
@@ -56,10 +56,11 @@ class FakeScheduler:
         self.urls = urls
         self.statuses = {u.id: CrawlStatus.PENDING for u in urls}
 
-    async def dequeue_batch(self, batch_size):
+    async def dequeue_stream(self, batch_size):
         pending = [u for u in self.urls if self.statuses[u.id] == CrawlStatus.PENDING]
         pending.sort(key=lambda u: u.last_crawl_at or datetime.min)
-        return pending[:batch_size]
+        for u in pending[:batch_size]:
+            yield u
 
     async def update_status(self, uid, status, error_message=None):  # noqa: ANN001, D401
         """更新狀態"""


### PR DESCRIPTION
## Summary
- 改為串流方式取出待抓取 URL，減少記憶體使用
- ProgressiveCrawler 採用產生器與 semaphore 控制併發
- 更新單元測試以支援新的串流介面

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37d7645208323b82f57e635043960