### PR TITLE
feat: respect robots rules before crawling

### DIFF
--- a/scripts/2_crawl_content.py
+++ b/scripts/2_crawl_content.py
@@ -12,6 +12,11 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config_manager import load_config
+from spider.crawlers.robots_handler import (
+    fetch_and_parse,
+    get_crawl_delay,
+    is_allowed,
+)
 from spider.crawlers.url_scheduler import URLScheduler
 from spider.crawlers.progressive_crawler import ProgressiveCrawler
 from spider.utils.connection_manager import EnhancedConnectionManager
@@ -25,27 +30,46 @@ load_config()
 
 logger = get_script_logger("crawl")
 
+# 允許的最大 crawl-delay 秒數
+MAX_CRAWL_DELAY = 30
 
-async def main(batch_size: int) -> None:
+
+async def main(domain: str, batch_size: int) -> None:
     """初始化並執行批次爬蟲"""
     async with EnhancedDatabaseManager() as db_manager:
         scheduler = URLScheduler(db_manager)
-        cm = EnhancedConnectionManager(rate_limiter=AdaptiveRateLimiter())
-        # 以 batch_size 同時設定批次大小與並行數量
-        crawler = ProgressiveCrawler(
-            scheduler,
-            cm,
-            RetryManager(),
-            batch_size=batch_size,
-            concurrency=batch_size,
-        )
-        processed = await crawler.crawl_batch()
-        logger.info(f"本次處理 {processed} 個 URL")
-        logger.log_statistics()
+        async with EnhancedConnectionManager(
+            rate_limiter=AdaptiveRateLimiter()
+        ) as cm:
+            # 下載並解析 robots.txt
+            await fetch_and_parse(domain, cm)
+            root_url = domain if domain.startswith("http") else f"https://{domain}/"
+            if not await is_allowed(root_url, cm):
+                logger.warning("該網站禁止爬取，終止流程")
+                return
+            crawl_delay = await get_crawl_delay(domain, cm)
+            if crawl_delay and crawl_delay > MAX_CRAWL_DELAY:
+                logger.warning(
+                    f"crawl-delay {crawl_delay}s 過大，終止流程"
+                )
+                return
+
+            # 以 batch_size 同時設定批次大小與並行數量
+            crawler = ProgressiveCrawler(
+                scheduler,
+                RetryManager(),
+                cm,
+                batch_size=batch_size,
+                concurrency=batch_size,
+            )
+            processed = await crawler.crawl_batch()
+            logger.info(f"本次處理 {processed} 個 URL")
+            logger.log_statistics()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="從排程器抓取內容")
+    parser.add_argument("--domain", required=True, help="目標網站網域或 URL")
     parser.add_argument(
         "--batch_size",
         type=int,
@@ -53,4 +77,4 @@ if __name__ == "__main__":
         help="每批處理的 URL 數量",
     )
     args = parser.parse_args()
-    asyncio.run(main(args.batch_size))
+    asyncio.run(main(args.domain, args.batch_size))

--- a/scripts/auto_pipeline.py
+++ b/scripts/auto_pipeline.py
@@ -18,6 +18,7 @@ from spider.crawlers.robots_handler import (
     get_crawl_delay,
     is_allowed,
 )
+from spider.utils.connection_manager import EnhancedConnectionManager
 from spider.utils.enhanced_logger import spider_logger
 
 # 建立日誌器
@@ -32,29 +33,31 @@ def import_script(name: str):
     return import_module(f"scripts.{name}")
 
 
+
 async def run_once(domain: str, batch_size: int):
     """執行一次完整流程"""
     logger.info("開始執行一次管線流程")
 
     # 先檢查 robots.txt 規範
-    await fetch_and_parse(domain)
-    root_url = domain if domain.startswith("http") else f"https://{domain}/"
-    if not await is_allowed(root_url):
-        logger.warning("該網站禁止爬取，終止流程")
-        return
-    crawl_delay = await get_crawl_delay(domain)
-    if crawl_delay and crawl_delay > MAX_CRAWL_DELAY:
-        logger.warning(
-            f"crawl-delay {crawl_delay}s 過大，終止流程"
-        )
-        return
+    async with EnhancedConnectionManager() as cm:
+        await fetch_and_parse(domain, cm)
+        root_url = domain if domain.startswith("http") else f"https://{domain}/"
+        if not await is_allowed(root_url, cm):
+            logger.warning("該網站禁止爬取，終止流程")
+            return
+        crawl_delay = await get_crawl_delay(domain, cm)
+        if crawl_delay and crawl_delay > MAX_CRAWL_DELAY:
+            logger.warning(
+                f"crawl-delay {crawl_delay}s 過大，終止流程",
+            )
+            return
 
     # discover 與 crawl 併發執行
     discover = import_script("1_discover_urls")
     crawl = import_script("2_crawl_content")
     await asyncio.gather(
         discover.main([domain]),
-        crawl.main(batch_size),
+        crawl.main(domain, batch_size),
     )
 
     # embed


### PR DESCRIPTION
## Summary
- check robots.txt and crawl-delay in auto pipeline and crawling script
- skip crawling when robots.txt forbids or delay too long

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a380b901888323956e709de5ae4b06