### PR TITLE
整理環境變數模板並移除敏感預設值

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,15 +3,15 @@
 # 資料庫連線設定
 # ======================================
 
-# 資料庫主機名稱或 IP，例如：localhost
+# 資料庫主機名稱或 IP，可為任何有效主機名稱或 IPv4/IPv6
 DB_HOST=localhost
-# 資料庫連接埠，預設為 5432
+# 資料庫連接埠，介於 1~65535 的整數，預設 5432
 DB_PORT=5432
-# 資料庫使用者名稱，例如：postgres
+# 資料庫使用者名稱，例如 postgres
 DB_USER=postgres
-# 資料庫密碼，請填入實際密碼
-DB_PASSWORD=postgres
-# 資料庫名稱，例如：postgres
+# 資料庫密碼，請填入實際密碼，任意字串
+DB_PASSWORD=
+# 資料庫名稱，例如 postgres
 DB_NAME=postgres
 
 
@@ -20,11 +20,11 @@ DB_NAME=postgres
 # 與 Supabase 服務相關的設定
 # ======================================
 
-# Supabase 專案 URL，例如：https://xxx.supabase.co
+# Supabase 專案 URL，例如 https://xxxx.supabase.co；留空表示不使用
 SUPABASE_URL=
-# 公開 API 金鑰，用於客戶端存取
+# 公開 API 金鑰，字串，用於客戶端存取，可留空
 SUPABASE_KEY=
-# 服務角色金鑰，僅供伺服器端使用（選填）
+# 服務角色金鑰，字串，僅供伺服器端使用（選填）
 SUPABASE_SERVICE_ROLE_KEY=
 
 
@@ -33,31 +33,31 @@ SUPABASE_SERVICE_ROLE_KEY=
 # 爬蟲與速率限制設定
 # ======================================
 
-# 是否以無頭模式執行瀏覽器 (true/false)
+# 是否以無頭模式執行瀏覽器，true 或 false
 CRAWLER_HEADLESS=true
-# 是否輸出詳細日誌 (true/false)
+# 是否輸出詳細日誌，true 或 false
 CRAWLER_VERBOSE=true
-# 每次請求的延遲秒數，可為小數
+# 每次請求的延遲秒數，浮點數 ≥0
 CRAWLER_DELAY=2.5
-# 單次請求逾時時間（毫秒）
+# 單次請求逾時時間（毫秒），正整數 ≥1
 CRAWLER_TIMEOUT=60000
-# 最大同時連線數
+# 最大同時連線數，正整數 ≥1
 CRAWLER_MAX_CONCURRENT=10
 
-# 基礎延遲最小值（秒）
+# 基礎延遲最小值（秒），浮點數 ≥0
 RATE_LIMIT_BASE_DELAY_MIN=1.0
-# 基礎延遲最大值（秒）
+# 基礎延遲最大值（秒），浮點數 ≥ RATE_LIMIT_BASE_DELAY_MIN
 RATE_LIMIT_BASE_DELAY_MAX=2.0
-# 允許的最大延遲（秒）
+# 允許的最大延遲（秒），浮點數 ≥ RATE_LIMIT_BASE_DELAY_MAX
 RATE_LIMIT_MAX_DELAY=30.0
-# 最大重試次數
+# 最大重試次數，非負整數
 RATE_LIMIT_MAX_RETRIES=2
 
-# 瀏覽器視窗寬度（像素）
+# 瀏覽器視窗寬度（像素），正整數
 BROWSER_VIEWPORT_WIDTH=1920
-# 瀏覽器視窗高度（像素）
+# 瀏覽器視窗高度（像素），正整數
 BROWSER_VIEWPORT_HEIGHT=1080
-# 瀏覽器使用者資料儲存路徑
+# 瀏覽器使用者資料儲存路徑，有效資料夾路徑
 BROWSER_USER_DATA_DIR=./user_data
 
 
@@ -66,30 +66,30 @@ BROWSER_USER_DATA_DIR=./user_data
 # 應用層設定，如嵌入模型與內容處理
 # ======================================
 
-# 向量嵌入模型名稱
+# 向量嵌入模型名稱，例如 BAAI/bge-large-zh-v1.5
 EMBEDDING_MODEL=BAAI/bge-large-zh-v1.5
-# 應用程式使用的密鑰，請自行設定
+# 應用程式使用的密鑰，任意字串，無預設值
 SECRET_KEY=
 
-# 每個分段的最大字元數
+# 每個分段的最大字元數，正整數
 CHUNK_WINDOW_SIZE=100
-# 分段滑動步長
+# 分段滑動步長，正整數，應 ≤ CHUNK_WINDOW_SIZE
 CHUNK_STEP_SIZE=50
 
-# 內容輸出格式，可選：html, markdown, plain_text, json
+# 內容輸出格式，必須為 html、markdown、plain_text、json 之一
 PREFERRED_CONTENT_FORMAT=markdown
-# 是否保留原始 HTML 結構 (true/false)
+# 是否保留原始 HTML 結構，true 或 false
 PRESERVE_HTML_STRUCTURE=false
-# 是否轉換為 Markdown (true/false)
+# 是否轉換為 Markdown，true 或 false
 CONVERT_TO_MARKDOWN=true
-# 是否清理多餘空白 (true/false)
+# 是否清理多餘空白，true 或 false
 CLEAN_WHITESPACE=true
 
-# 目標網址，單一 URL
-TARGET_URL=https://money.udn.com/robots.txt
+# 目標網址，單一 HTTP/HTTPS URL
+TARGET_URL=
 
-# 儲存結果的資料夾
+# 儲存結果的資料夾，有效資料夾路徑
 RESULTS_DIR=ex_result
-# 最多處理的 URL 數量
+# 最多處理的 URL 數量，正整數
 MAX_URLS_TO_PROCESS=10
 


### PR DESCRIPTION
## 摘要
- 依模組整理 `.env.template`，新增繁體中文註解與可接受值範圍
- 移除預設資料庫密碼與示範網址，改留空供使用者自行填寫

## 測試
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a385df93c8832383289daee231c7e9