### PR TITLE
feat: 更新爬取流程支援批次參數

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PYTHON := python3
 DOMAIN ?= $(TARGET_URL)
 QUERY ?= "What is Retrieval-Augmented Generation?"
 LIMIT ?= 100
-MAX_URLS ?= 100
+BATCH_SIZE ?= 10  # 每批處理的 URL 數量
 
 # --- 核心 RAG 流程 ---
 
@@ -23,8 +23,8 @@ discover:
 	@$(PYTHON) -m scripts.1_discover_urls --domains $(DOMAIN)
 
 crawl:
-	@echo "📄  步驟 2: 爬取已發現的 URL 內容 (上限: $(MAX_URLS))..."
-	@$(PYTHON) -m scripts.2_crawl_content --max_urls $(MAX_URLS)
+	@echo "📄  步驟 2: 爬取已發現的 URL 內容..."
+	@$(PYTHON) -m scripts.2_crawl_content --domain $(DOMAIN) --batch_size $(BATCH_SIZE)
 
 embed:
 	@echo "🧠  步驟 3: 為新文章生成向量嵌入 (上限: $(LIMIT))..."
@@ -38,7 +38,7 @@ search:
 run-pipeline:
 	@echo "🚀  執行完整的數據導入流程 for $(DOMAIN)..."
 	@make discover DOMAIN=$(DOMAIN)
-	@make crawl
+	@make crawl DOMAIN=$(DOMAIN)
 	@make embed
 	@echo "✅  數據導入流程完成！"
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agentic_rag/
 | 指令 | 說明 |
 |------|------|
 | `make discover DOMAIN=https://example.com` | 解析 sitemap 並寫入待爬取 URL |
-| `make crawl MAX_URLS=100` | 依據資料庫中的 URL 進行內容抓取 |
+| `make crawl DOMAIN=https://example.com BATCH_SIZE=10` | 依據資料庫中的 URL 進行內容抓取 |
 | `make embed LIMIT=100` | 為新文章產生向量嵌入 |
 | `make search QUERY="關鍵問題"` | 進行語義搜尋 |
 | `make migrate-supabase` | 將 PostgreSQL 資料遷移至 Supabase |


### PR DESCRIPTION
## Summary
- 改寫 `crawl` 目標，支援 `--domain` 與 `--batch_size` 參數並移除 `MAX_URLS`
- `run-pipeline` 轉呼叫 `make crawl DOMAIN=$(DOMAIN)` 確保帶入網域
- 更新 README 範例以反映最新參數

## Testing
- `make test`
- `make run-pipeline DOMAIN=https://example.com` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a385d684708323ad03b98148071d0b