### PR TITLE
feat: 串流排程與負載測試優化

### DIFF
--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -45,9 +45,10 @@ class InMemoryDBManager:
         """不需特別清理資源"""
         return False
 
-    async def bulk_create_discovered_urls(
+    async def bulk_insert_discovered_urls(
         self, models: List[DiscoveredURLModel]
     ) -> int:
+        """模擬批次寫入資料庫"""
         for m in models:
             self.urls[m.id] = m
         return len(models)
@@ -146,8 +147,8 @@ async def main() -> None:
 
         crawler = ProgressiveCrawler(
             scheduler,
-            connection_manager,
             retry_manager,
+            connection_manager,
             batch_size=args.batch_size,
             concurrency=args.concurrency,
         )

--- a/spider/crawlers/url_scheduler.py
+++ b/spider/crawlers/url_scheduler.py
@@ -100,13 +100,15 @@ class URLScheduler:
         return total
 
     async def dequeue_stream(self, batch_size: int):
-        """以串流方式取出待處理的 URL"""
+        """以串流方式逐批取出待處理 URL"""
 
         while True:
             batch = await self.db_manager.get_pending_urls(batch_size)
             if not batch:
                 break
             for item in batch:
+                # 先將狀態設為 CRAWLING，避免重複讀取
+                await self.update_status(item.id, CrawlStatus.CRAWLING)
                 yield item
 
     async def update_status(self, url_id: str, status: CrawlStatus, error_message: str | None = None) -> bool:


### PR DESCRIPTION
## Summary
- 使用 `asyncio.Semaphore` 控制並發並透過 `dequeue_stream` 串流取得 URL
- URLScheduler 取得批次時即標記為 CRAWLING 避免重複處理
- 新增負載測試腳本並修正記憶體資料庫介面

## Testing
- `pytest`
- `python scripts/load_test.py --total 100 --batch_size 10 --concurrency 5 --rps 50`

------
https://chatgpt.com/codex/tasks/task_e_68a38825149883239ec38508d5afec6d