### PR TITLE
feat: integrate rate limiter with crawl4ai hooks

### DIFF
--- a/spider/tests/test_rate_limiter_behavior.py
+++ b/spider/tests/test_rate_limiter_behavior.py
@@ -1,0 +1,72 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from spider.utils.rate_limiter import RateLimiter, AdaptiveRateLimiter, RateLimitConfig
+
+
+class DummyStrategy:
+    """簡化策略物件，記錄掛載的 hooks"""
+
+    def __init__(self) -> None:
+        self.hooks: dict[str, object] = {}
+
+    def set_hook(self, name: str, func: object) -> None:
+        self.hooks[name] = func
+
+
+class DummySession:
+    """提供 `crawler_strategy` 的假 session"""
+
+    def __init__(self) -> None:
+        self.crawler_strategy = DummyStrategy()
+
+
+@pytest.mark.asyncio
+async def test_rps_limit_enforced(monkeypatch) -> None:
+    """確認 `requests_per_second` 限制會生效"""
+
+    # 固定抖動為 0 以穩定測試時間
+    from spider.utils import rate_limiter as rl_module
+
+    monkeypatch.setattr(rl_module.random, "uniform", lambda a, b: 0.0)
+
+    session = DummySession()
+    rl = RateLimiter(
+        RateLimitConfig(requests_per_second=2, burst_size=1, adaptive=False, min_delay=0.0)
+    )
+    rl.apply_to_crawl4ai(session)
+
+    hook = session.crawler_strategy.hooks["before_request"]
+    start = time.perf_counter()
+    for _ in range(4):
+        await hook("https://example.com", {})
+    elapsed = time.perf_counter() - start
+
+    assert elapsed >= 1.0  # 需等待兩次，每次 0.5 秒
+
+
+@pytest.mark.asyncio
+async def test_crawl_delay_respected(monkeypatch) -> None:
+    """確認 robots 的 `crawl-delay` 會被套用"""
+
+    from spider.utils import rate_limiter as rl_module
+
+    monkeypatch.setattr(rl_module.random, "uniform", lambda a, b: 0.0)
+
+    session = DummySession()
+    session.robots_handler = SimpleNamespace(get_crawl_delay=lambda domain: 0.2)
+
+    rl = AdaptiveRateLimiter(
+        RateLimitConfig(requests_per_second=100, burst_size=1, adaptive=False, min_delay=0.0)
+    )
+    rl.apply_to_crawl4ai(session)
+
+    hook = session.crawler_strategy.hooks["before_request"]
+    start = time.perf_counter()
+    await hook("https://example.com", {})
+    await hook("https://example.com", {})
+    elapsed = time.perf_counter() - start
+
+    assert elapsed >= 0.2

--- a/spider/utils/connection_manager.py
+++ b/spider/utils/connection_manager.py
@@ -302,7 +302,22 @@ class EnhancedConnectionManager:
     async def post(self, url: str, **kwargs) -> aiohttp.ClientResponse:
         """POST 請求"""
         return await self.request("POST", url, **kwargs)
-    
+
+    def create_crawler(self, *args, **kwargs):
+        """建立 AsyncWebCrawler 並自動掛載限速 hook"""
+        try:
+            from crawl4ai import AsyncWebCrawler
+        except Exception as e:  # noqa: BLE001
+            raise ImportError("未安裝 crawl4ai，無法建立 AsyncWebCrawler") from e
+
+        crawler = AsyncWebCrawler(*args, **kwargs)
+
+        # 若限速器支援 crawl4ai，建立後立即掛載
+        if hasattr(self._rate_limiter, "apply_to_crawl4ai"):
+            self._rate_limiter.apply_to_crawl4ai(crawler)
+
+        return crawler
+
     async def close(self):
         """關閉連接管理器"""
         if self._session:


### PR DESCRIPTION
## Summary
- add helper to create AsyncWebCrawler with rate limiting
- enable RateLimiter to attach before_request hooks for crawl4ai
- test rate limiter to respect RPS and crawl-delay

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3bdc57c248323bcdee438043c10e8